### PR TITLE
Added the following capabilities:

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ The tabs component is where your clickable tabs are generated. It has a required
 * The `tabs` attribute expects an array of one or more objects which contains at least an `id` property and a `label` property.
   * The `id` property is used to identify which pane this tab will open.
   * The `label` property is the value displayed.
-  * The optional property `active` allows us to specify if this tab is the default active tab.
+  * The optional property `active` allows us to specify if this tab is the default active tab. This property is updated when the active tab changes.
   * The optional property `disabled` allows us to disable a certain tab.
   * The optional property `tooltip` shows a tooltip beside the specified tab. For more info see the [Bootstrap documentation](https://getbootstrap.com/docs/4.1/components/tooltips/).
 * The `class` attribute is copied from the custom element to the inner `UL` element. Useful if you want to use something else than tabs, like pills or inline. For more info see the [Bootstrap documentation](https://getbootstrap.com/docs/4.1/components/navs/).
 * If the `translate` attribute is set to `true` the value provided in `label` will be used as a translation key according to [`aurelia-i18n`](http://aurelia.io/docs/plugins/i18n). The `translate` attribute is `false` by default.
 
 ```html
-<aup-tabs class="nav-tabs" tabs.bind="myTabs" translate="true"></aup-tabs>
+<aup-tabs class="nav-tabs" tabs.bind="myTabs" active-tab-id.from-view="tabId" translate="true"></aup-tabs>
 ```
 
 ```javascript
@@ -89,7 +89,8 @@ export class App {
 }
 ```
 
-When a tab is clicked, the event `aurelia-plugins:tabs:tab-clicked:{tab-id}` will be published, where `{tab-id}` is the corresponding id as defined in the `tabs` array. The payload is the click `event`.
+When a tab is clicked, the event `aurelia-plugins:tabs:tab-clicked:{tab-id}` will be published, where `{tab-id}` is the corresponding id as defined in the `tabs` array. The payload is the click `event`. The active-tag-id bound property will also be updatedf. 
+The event `aurelia-plugins:tabs:active-tab-changed` to allow subscribing to a single event, with a payload containing the Ids of the tabs in the form: `{from: currentActiveId, to: targetId}`
 
 ### Tab Content
 

--- a/dist/amd/aurelia-plugins-tabs-tabs.d.ts
+++ b/dist/amd/aurelia-plugins-tabs-tabs.d.ts
@@ -4,9 +4,14 @@ export declare class Tabs {
     class: string;
     tabs: any;
     translate: boolean;
+    activeTabId: any;
     constructor(element: any, eventAggregator: any);
     attached(): void;
     tabsChanged(): void;
     click(tab: any, event: any): void;
     _refresh(): void;
+    _addTabActiveClass(tabId: any): boolean;
+    _updateActiveStatusInBoundTabs(activeId: any, targetId: any): void;
+    _setTabActiveState(tabId: any, newActiveState: any): void;
+    _findTab(targetId: any): any;
 }

--- a/dist/amd/aurelia-plugins-tabs-tabs.js
+++ b/dist/amd/aurelia-plugins-tabs-tabs.js
@@ -1,4 +1,4 @@
-define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', 'aurelia-templating'], function (exports, _aureliaDependencyInjection, _aureliaEventAggregator, _aureliaTemplating) {
+define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', 'aurelia-templating', 'aurelia-binding'], function (exports, _aureliaDependencyInjection, _aureliaEventAggregator, _aureliaTemplating, _aureliaBinding) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
@@ -55,9 +55,9 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', '
     throw new Error('Decorating class property failed. Please ensure that transform-class-properties is enabled.');
   }
 
-  var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3;
+  var _dec, _dec2, _dec3, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4;
 
-  var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tabs'), _dec2 = (0, _aureliaDependencyInjection.inject)(Element, _aureliaEventAggregator.EventAggregator), _dec(_class = _dec2(_class = (_class2 = function () {
+  var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tabs'), _dec2 = (0, _aureliaDependencyInjection.inject)(Element, _aureliaEventAggregator.EventAggregator), _dec3 = (0, _aureliaTemplating.bindable)({ defaultBindingMode: _aureliaBinding.bindingMode.toView }), _dec(_class = _dec2(_class = (_class2 = function () {
     function Tabs(element, eventAggregator) {
       _classCallCheck(this, Tabs);
 
@@ -66,6 +66,8 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', '
       _initDefineProp(this, 'tabs', _descriptor2, this);
 
       _initDefineProp(this, 'translate', _descriptor3, this);
+
+      _initDefineProp(this, 'activeTabId', _descriptor4, this);
 
       this._element = element;
       this._eventAggregator = eventAggregator;
@@ -80,29 +82,72 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', '
     };
 
     Tabs.prototype.click = function click(tab, event) {
+      var currentActiveId = void 0;
+      var targetId = void 0;
       event.stopPropagation();
       if (tab.disabled) return;
       var target = event.target;
-      var active = this._element.querySelector('a.nav-link.active');
-      if (target === active) return;
+      var currentActiveTab = this._element.querySelector('a.nav-link.active');
+      if (target === currentActiveTab) return;
       var targetHref = target.getAttribute('href');
       target.classList.add('active');
       document.querySelector(targetHref).classList.add('active');
-      if (active) {
-        var activeHref = active.getAttribute('href');
-        active.classList.remove('active');
-        document.querySelector(activeHref).classList.remove('active');
+      targetId = targetHref.replace('#', '');
+      if (currentActiveTab) {
+        var currentActiveHref = currentActiveTab.getAttribute('href');
+        currentActiveId = currentActiveHref.replace('#', '');
+        currentActiveTab.classList.remove('active');
+        document.querySelector(currentActiveHref).classList.remove('active');
       }
-      this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetHref.replace('#', ''), event);
+      this._updateActiveStatusInBoundTabs(currentActiveId, targetId);
+      this._eventAggregator.publish('aurelia-plugins:tabs:active-tab-changed', { from: currentActiveId, to: targetId });
+      this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetId, event);
     };
 
     Tabs.prototype._refresh = function _refresh() {
+      var _this = this;
+
       var active = this.tabs.find(function (tab) {
         return tab.active;
       });
       if (!active) return;
-      var element = document.querySelector('#' + active.id);
-      if (element) element.classList.add('active');
+      this.activeTabId = active.id;
+      if (!this._addTabActiveClass(active.id)) {
+        setTimeout(function () {
+          _this._addTabActiveClass(active.id);
+        }, 0);
+      }
+    };
+
+    Tabs.prototype._addTabActiveClass = function _addTabActiveClass(tabId) {
+      var element = document.querySelector('#' + tabId);
+      if (element) {
+        element.classList.add('active');
+      }
+      return !!element;
+    };
+
+    Tabs.prototype._updateActiveStatusInBoundTabs = function _updateActiveStatusInBoundTabs(activeId, targetId) {
+      this._setTabActiveState(activeId, false);
+      this._setTabActiveState(targetId, true);
+    };
+
+    Tabs.prototype._setTabActiveState = function _setTabActiveState(tabId, newActiveState) {
+      if (tabId) {
+        var tab = this._findTab(tabId);
+        if (tab) {
+          tab.active = newActiveState;
+          if (newActiveState) {
+            this.activeTabId = tabId;
+          }
+        }
+      }
+    };
+
+    Tabs.prototype._findTab = function _findTab(targetId) {
+      return this.tabs.find(function (tab) {
+        return tab.id === targetId;
+      });
     };
 
     return Tabs;
@@ -118,6 +163,11 @@ define(['exports', 'aurelia-dependency-injection', 'aurelia-event-aggregator', '
     enumerable: true,
     initializer: function initializer() {
       return false;
+    }
+  }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'activeTabId', [_dec3], {
+    enumerable: true,
+    initializer: function initializer() {
+      return null;
     }
   })), _class2)) || _class) || _class);
 });

--- a/dist/commonjs/aurelia-plugins-tabs-tabs.d.ts
+++ b/dist/commonjs/aurelia-plugins-tabs-tabs.d.ts
@@ -4,9 +4,14 @@ export declare class Tabs {
     class: string;
     tabs: any;
     translate: boolean;
+    activeTabId: any;
     constructor(element: any, eventAggregator: any);
     attached(): void;
     tabsChanged(): void;
     click(tab: any, event: any): void;
     _refresh(): void;
+    _addTabActiveClass(tabId: any): boolean;
+    _updateActiveStatusInBoundTabs(activeId: any, targetId: any): void;
+    _setTabActiveState(tabId: any, newActiveState: any): void;
+    _findTab(targetId: any): any;
 }

--- a/dist/commonjs/aurelia-plugins-tabs-tabs.js
+++ b/dist/commonjs/aurelia-plugins-tabs-tabs.js
@@ -5,13 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Tabs = undefined;
 
-var _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3;
+var _dec, _dec2, _dec3, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4;
 
 var _aureliaDependencyInjection = require('aurelia-dependency-injection');
 
 var _aureliaEventAggregator = require('aurelia-event-aggregator');
 
 var _aureliaTemplating = require('aurelia-templating');
+
+var _aureliaBinding = require('aurelia-binding');
 
 function _initDefineProp(target, property, descriptor, context) {
   if (!descriptor) return;
@@ -58,7 +60,7 @@ function _initializerWarningHelper(descriptor, context) {
   throw new Error('Decorating class property failed. Please ensure that transform-class-properties is enabled.');
 }
 
-var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tabs'), _dec2 = (0, _aureliaDependencyInjection.inject)(Element, _aureliaEventAggregator.EventAggregator), _dec(_class = _dec2(_class = (_class2 = function () {
+var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tabs'), _dec2 = (0, _aureliaDependencyInjection.inject)(Element, _aureliaEventAggregator.EventAggregator), _dec3 = (0, _aureliaTemplating.bindable)({ defaultBindingMode: _aureliaBinding.bindingMode.toView }), _dec(_class = _dec2(_class = (_class2 = function () {
   function Tabs(element, eventAggregator) {
     _classCallCheck(this, Tabs);
 
@@ -67,6 +69,8 @@ var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tab
     _initDefineProp(this, 'tabs', _descriptor2, this);
 
     _initDefineProp(this, 'translate', _descriptor3, this);
+
+    _initDefineProp(this, 'activeTabId', _descriptor4, this);
 
     this._element = element;
     this._eventAggregator = eventAggregator;
@@ -81,29 +85,72 @@ var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tab
   };
 
   Tabs.prototype.click = function click(tab, event) {
+    var currentActiveId = void 0;
+    var targetId = void 0;
     event.stopPropagation();
     if (tab.disabled) return;
     var target = event.target;
-    var active = this._element.querySelector('a.nav-link.active');
-    if (target === active) return;
+    var currentActiveTab = this._element.querySelector('a.nav-link.active');
+    if (target === currentActiveTab) return;
     var targetHref = target.getAttribute('href');
     target.classList.add('active');
     document.querySelector(targetHref).classList.add('active');
-    if (active) {
-      var activeHref = active.getAttribute('href');
-      active.classList.remove('active');
-      document.querySelector(activeHref).classList.remove('active');
+    targetId = targetHref.replace('#', '');
+    if (currentActiveTab) {
+      var currentActiveHref = currentActiveTab.getAttribute('href');
+      currentActiveId = currentActiveHref.replace('#', '');
+      currentActiveTab.classList.remove('active');
+      document.querySelector(currentActiveHref).classList.remove('active');
     }
-    this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetHref.replace('#', ''), event);
+    this._updateActiveStatusInBoundTabs(currentActiveId, targetId);
+    this._eventAggregator.publish('aurelia-plugins:tabs:active-tab-changed', { from: currentActiveId, to: targetId });
+    this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetId, event);
   };
 
   Tabs.prototype._refresh = function _refresh() {
+    var _this = this;
+
     var active = this.tabs.find(function (tab) {
       return tab.active;
     });
     if (!active) return;
-    var element = document.querySelector('#' + active.id);
-    if (element) element.classList.add('active');
+    this.activeTabId = active.id;
+    if (!this._addTabActiveClass(active.id)) {
+      setTimeout(function () {
+        _this._addTabActiveClass(active.id);
+      }, 0);
+    }
+  };
+
+  Tabs.prototype._addTabActiveClass = function _addTabActiveClass(tabId) {
+    var element = document.querySelector('#' + tabId);
+    if (element) {
+      element.classList.add('active');
+    }
+    return !!element;
+  };
+
+  Tabs.prototype._updateActiveStatusInBoundTabs = function _updateActiveStatusInBoundTabs(activeId, targetId) {
+    this._setTabActiveState(activeId, false);
+    this._setTabActiveState(targetId, true);
+  };
+
+  Tabs.prototype._setTabActiveState = function _setTabActiveState(tabId, newActiveState) {
+    if (tabId) {
+      var tab = this._findTab(tabId);
+      if (tab) {
+        tab.active = newActiveState;
+        if (newActiveState) {
+          this.activeTabId = tabId;
+        }
+      }
+    }
+  };
+
+  Tabs.prototype._findTab = function _findTab(targetId) {
+    return this.tabs.find(function (tab) {
+      return tab.id === targetId;
+    });
   };
 
   return Tabs;
@@ -119,5 +166,10 @@ var Tabs = exports.Tabs = (_dec = (0, _aureliaTemplating.customElement)('aup-tab
   enumerable: true,
   initializer: function initializer() {
     return false;
+  }
+}), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'activeTabId', [_dec3], {
+  enumerable: true,
+  initializer: function initializer() {
+    return null;
   }
 })), _class2)) || _class) || _class);

--- a/dist/es2015/aurelia-plugins-tabs-tabs.d.ts
+++ b/dist/es2015/aurelia-plugins-tabs-tabs.d.ts
@@ -4,9 +4,14 @@ export declare class Tabs {
     class: string;
     tabs: any;
     translate: boolean;
+    activeTabId: any;
     constructor(element: any, eventAggregator: any);
     attached(): void;
     tabsChanged(): void;
     click(tab: any, event: any): void;
     _refresh(): void;
+    _addTabActiveClass(tabId: any): boolean;
+    _updateActiveStatusInBoundTabs(activeId: any, targetId: any): void;
+    _setTabActiveState(tabId: any, newActiveState: any): void;
+    _findTab(targetId: any): any;
 }

--- a/dist/system/aurelia-plugins-tabs-tabs.d.ts
+++ b/dist/system/aurelia-plugins-tabs-tabs.d.ts
@@ -4,9 +4,14 @@ export declare class Tabs {
     class: string;
     tabs: any;
     translate: boolean;
+    activeTabId: any;
     constructor(element: any, eventAggregator: any);
     attached(): void;
     tabsChanged(): void;
     click(tab: any, event: any): void;
     _refresh(): void;
+    _addTabActiveClass(tabId: any): boolean;
+    _updateActiveStatusInBoundTabs(activeId: any, targetId: any): void;
+    _setTabActiveState(tabId: any, newActiveState: any): void;
+    _findTab(targetId: any): any;
 }

--- a/dist/system/aurelia-plugins-tabs-tabs.js
+++ b/dist/system/aurelia-plugins-tabs-tabs.js
@@ -1,9 +1,9 @@
 'use strict';
 
-System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'aurelia-templating'], function (_export, _context) {
+System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'aurelia-templating', 'aurelia-binding'], function (_export, _context) {
   "use strict";
 
-  var inject, EventAggregator, bindable, customElement, _dec, _dec2, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, Tabs;
+  var inject, EventAggregator, bindable, customElement, bindingMode, _dec, _dec2, _dec3, _class, _desc, _value, _class2, _descriptor, _descriptor2, _descriptor3, _descriptor4, Tabs;
 
   function _initDefineProp(target, property, descriptor, context) {
     if (!descriptor) return;
@@ -62,9 +62,11 @@ System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'au
     }, function (_aureliaTemplating) {
       bindable = _aureliaTemplating.bindable;
       customElement = _aureliaTemplating.customElement;
+    }, function (_aureliaBinding) {
+      bindingMode = _aureliaBinding.bindingMode;
     }],
     execute: function () {
-      _export('Tabs', Tabs = (_dec = customElement('aup-tabs'), _dec2 = inject(Element, EventAggregator), _dec(_class = _dec2(_class = (_class2 = function () {
+      _export('Tabs', Tabs = (_dec = customElement('aup-tabs'), _dec2 = inject(Element, EventAggregator), _dec3 = bindable({ defaultBindingMode: bindingMode.toView }), _dec(_class = _dec2(_class = (_class2 = function () {
         function Tabs(element, eventAggregator) {
           _classCallCheck(this, Tabs);
 
@@ -73,6 +75,8 @@ System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'au
           _initDefineProp(this, 'tabs', _descriptor2, this);
 
           _initDefineProp(this, 'translate', _descriptor3, this);
+
+          _initDefineProp(this, 'activeTabId', _descriptor4, this);
 
           this._element = element;
           this._eventAggregator = eventAggregator;
@@ -87,29 +91,72 @@ System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'au
         };
 
         Tabs.prototype.click = function click(tab, event) {
+          var currentActiveId = void 0;
+          var targetId = void 0;
           event.stopPropagation();
           if (tab.disabled) return;
           var target = event.target;
-          var active = this._element.querySelector('a.nav-link.active');
-          if (target === active) return;
+          var currentActiveTab = this._element.querySelector('a.nav-link.active');
+          if (target === currentActiveTab) return;
           var targetHref = target.getAttribute('href');
           target.classList.add('active');
           document.querySelector(targetHref).classList.add('active');
-          if (active) {
-            var activeHref = active.getAttribute('href');
-            active.classList.remove('active');
-            document.querySelector(activeHref).classList.remove('active');
+          targetId = targetHref.replace('#', '');
+          if (currentActiveTab) {
+            var currentActiveHref = currentActiveTab.getAttribute('href');
+            currentActiveId = currentActiveHref.replace('#', '');
+            currentActiveTab.classList.remove('active');
+            document.querySelector(currentActiveHref).classList.remove('active');
           }
-          this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetHref.replace('#', ''), event);
+          this._updateActiveStatusInBoundTabs(currentActiveId, targetId);
+          this._eventAggregator.publish('aurelia-plugins:tabs:active-tab-changed', { from: currentActiveId, to: targetId });
+          this._eventAggregator.publish('aurelia-plugins:tabs:tab-clicked:' + targetId, event);
         };
 
         Tabs.prototype._refresh = function _refresh() {
+          var _this = this;
+
           var active = this.tabs.find(function (tab) {
             return tab.active;
           });
           if (!active) return;
-          var element = document.querySelector('#' + active.id);
-          if (element) element.classList.add('active');
+          this.activeTabId = active.id;
+          if (!this._addTabActiveClass(active.id)) {
+            setTimeout(function () {
+              _this._addTabActiveClass(active.id);
+            }, 0);
+          }
+        };
+
+        Tabs.prototype._addTabActiveClass = function _addTabActiveClass(tabId) {
+          var element = document.querySelector('#' + tabId);
+          if (element) {
+            element.classList.add('active');
+          }
+          return !!element;
+        };
+
+        Tabs.prototype._updateActiveStatusInBoundTabs = function _updateActiveStatusInBoundTabs(activeId, targetId) {
+          this._setTabActiveState(activeId, false);
+          this._setTabActiveState(targetId, true);
+        };
+
+        Tabs.prototype._setTabActiveState = function _setTabActiveState(tabId, newActiveState) {
+          if (tabId) {
+            var tab = this._findTab(tabId);
+            if (tab) {
+              tab.active = newActiveState;
+              if (newActiveState) {
+                this.activeTabId = tabId;
+              }
+            }
+          }
+        };
+
+        Tabs.prototype._findTab = function _findTab(targetId) {
+          return this.tabs.find(function (tab) {
+            return tab.id === targetId;
+          });
         };
 
         return Tabs;
@@ -125,6 +172,11 @@ System.register(['aurelia-dependency-injection', 'aurelia-event-aggregator', 'au
         enumerable: true,
         initializer: function initializer() {
           return false;
+        }
+      }), _descriptor4 = _applyDecoratedDescriptor(_class2.prototype, 'activeTabId', [_dec3], {
+        enumerable: true,
+        initializer: function initializer() {
+          return null;
         }
       })), _class2)) || _class) || _class));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-plugins-tabs",
-  "version": "2.6.3",
+  "version": "2.6.9",
   "description": "A tabs plugin for Aurelia.",
   "keywords": [
     "aurelia",
@@ -20,6 +20,7 @@
     "url": "git://github.com/aurelia-plugins/aurelia-plugins-tabs.git"
   },
   "dependencies": {
+    "aurelia-binding": "^2.5.0",
     "aurelia-dependency-injection": "^1.3.2",
     "aurelia-event-aggregator": "^1.0.1",
     "aurelia-pal": "^1.8.0",

--- a/src/aurelia-plugins-tabs-tabs.js
+++ b/src/aurelia-plugins-tabs-tabs.js
@@ -2,6 +2,7 @@
 import {inject} from 'aurelia-dependency-injection';
 import {EventAggregator} from 'aurelia-event-aggregator';
 import {bindable, customElement} from 'aurelia-templating';
+import { bindingMode } from 'aurelia-binding';
 
 
 // CLASS ATTRIBUTES
@@ -19,6 +20,8 @@ export class Tabs {
   @bindable class = 'nav-tabs';
   @bindable tabs;
   @bindable translate = false;
+  @bindable({ defaultBindingMode: bindingMode.toView }) // out
+  activeTabId = null;
 
   // CONSTRUCTOR
   constructor(element, eventAggregator) {
@@ -38,27 +41,68 @@ export class Tabs {
 
   // PUBLIC METHODS
   click(tab, event) {
+    let currentActiveId;
+    let targetId;
     event.stopPropagation();
     if (tab.disabled) return;
     const target = event.target;
-    const active = this._element.querySelector('a.nav-link.active');
-    if (target === active) return;
+    const currentActiveTab = this._element.querySelector('a.nav-link.active');
+    if (target === currentActiveTab) return;
     const targetHref = target.getAttribute('href');
     target.classList.add('active');
     document.querySelector(targetHref).classList.add('active');
-    if (active) {
-      const activeHref = active.getAttribute('href');
-      active.classList.remove('active');
-      document.querySelector(activeHref).classList.remove('active');
+    targetId = targetHref.replace('#', '');
+    if (currentActiveTab) {
+      const currentActiveHref = currentActiveTab.getAttribute('href');
+      currentActiveId = currentActiveHref.replace('#', '');
+      currentActiveTab.classList.remove('active');
+      document.querySelector(currentActiveHref).classList.remove('active');
     }
-    this._eventAggregator.publish(`aurelia-plugins:tabs:tab-clicked:${targetHref.replace('#', '')}`, event);
+    this._updateActiveStatusInBoundTabs(currentActiveId, targetId);
+    this._eventAggregator.publish(`aurelia-plugins:tabs:active-tab-changed`, {from: currentActiveId, to: targetId});
+    this._eventAggregator.publish(`aurelia-plugins:tabs:tab-clicked:${targetId}`, event);
   }
 
   // PRIVATE METHODS
   _refresh() {
     const active = this.tabs.find(tab => tab.active);
     if (!active) return;
-    const element = document.querySelector(`#${active.id}`);
-    if (element) element.classList.add('active');
+    this.activeTabId = active.id;
+    if (!this._addTabActiveClass(active.id)) {
+      // No element there?! Give it another chance as may not have entered the dom yet
+      setTimeout(() => {
+        this._addTabActiveClass(active.id);
+      }, 0);
+    }
   }
+
+  _addTabActiveClass(tabId) {
+    const element = document.querySelector(`#${tabId}`);
+    if (element) {
+      element.classList.add('active');
+    }
+    return !!element;
+  }
+
+  _updateActiveStatusInBoundTabs(activeId, targetId) {
+    this._setTabActiveState(activeId, false);
+    this._setTabActiveState(targetId, true);
+  }
+
+  _setTabActiveState(tabId, newActiveState) {
+    if (tabId) {
+      let tab = this._findTab(tabId);
+      if (tab) {
+        tab.active = newActiveState;
+        if (newActiveState) {
+          this.activeTabId = tabId;
+        }
+      }
+    }
+  }
+
+  _findTab(targetId) {
+    return this.tabs.find(tab => tab.id === targetId);
+  }
+
 }


### PR DESCRIPTION
'active-tab-id' - indicates the selected tab id
'aurelia-plugins:tabs:active-tab-changed' is raised when any tab change
occurs
'active' is now updated in the 'tabs' collection